### PR TITLE
fix: repair ci debug build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,13 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                  - os: ubuntu-20.04
+                  - os: ubuntu-22.04
                     make: test-debug
-                    info: g++-9 + test-debug
+                    info: clang + test-debug
 
-                  - os: ubuntu-20.04
+                  - os: ubuntu-22.04
                     make: test-release
-                    info: g++-9 + test-release
+                    info: clang + test-release
 
         name: '${{matrix.os}}: ${{matrix.info}}'
         runs-on: ${{matrix.os}}
@@ -44,11 +44,16 @@ jobs:
             run: |
                 sudo apt update
                 sudo apt install --allow-downgrades -y pep8 $(cat third_party/userver/scripts/docs/en/deps/${{matrix.os}}.md | tr '\n' ' ')
+                sudo apt install --allow-downgrades -y $(cat deps/${{matrix.os}}.txt | tr '\n' ' ')
 
           - name: Setup ccache
             run: |
                 ccache -M 2.0GB
                 ccache -s
+
+          - name: Clang version
+            run: |
+                clang --version
 
           - name: Run ${{matrix.make}}
             run: |

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ compile_commands.json
 cmake-build-*
 Testing/
 configs/static_config.yaml
+configs/config_vars_testing.yaml

--- a/deps/ubuntu-22.04.txt
+++ b/deps/ubuntu-22.04.txt
@@ -1,0 +1,2 @@
+libpq5=14.6-0ubuntu0.22.04.1
+libpq-dev=14.6-0ubuntu0.22.04.1


### PR DESCRIPTION
- Correct action descriptions.
- Install fixed libpq version

Ubuntu 22.04 CI runner image uses official Postgres APT repository which has a problem: main package list contains no libpq version for postgresql-14, which leads to linker error because of missing symbols